### PR TITLE
fix(pipeline): resize input image for img2img

### DIFF
--- a/stable_diffusion_pytorch/pipeline.py
+++ b/stable_diffusion_pytorch/pipeline.py
@@ -124,6 +124,7 @@ def generate(
             encoder.to(device)
             processed_input_images = []
             for input_image in input_images:
+                input_image = input_image.resize((width, height))
                 input_image = np.array(input_image)
                 input_image = torch.tensor(input_image, dtype=torch.float32)
                 input_image = util.rescale(input_image, (0, 255), (-1, 1))


### PR DESCRIPTION
Hello @kjsman,
I noticed that the img2img pipeline does not seem to be working when the image does not match the `width` and `height` parameters. Consider the following example (taken from the [tensorflow implementation](https://github.com/divamgupta/stable-diffusion-tensorflow) you referred this work to)

```py
from PIL import Image
img = Image.open("inp.jpg")
input_images = [img]

... 

pipeline.generate(
          prompts=prompts, 
          uncond_prompts=uncond_prompts,
          input_images=input_images,
              ...
 )
```

where `inp.jpg` is 

```shell
>> wget https://pyxis.nymag.com/v1/imgs/24c/d4a/6fdd64a7c835b8325065b72e6fbfe59fb9-09-family-drawing1.rsquare.w330.jpg -O inp.jpg
```

This leads to the following error

```py
RuntimeError: The size of tensor a (42) must match the size of tensor b (41) at non-singleton dimension 3
```

however including the resizing (which is something the original repo does as well) it works as expected. Do you agree ? 

One last thing: I find it a little "user-unfriendly" to force him to pass `PIL.Image` objects.  Allowing the user to specify the name / path of image as a string is easy to implement  and much more "friendly". If you agree on this, I can add an extra commit to this pull request adding this feature. 